### PR TITLE
Use line-wise selection instead of character-wise

### DIFF
--- a/autoload/textobj/chunk.vim
+++ b/autoload/textobj/chunk.vim
@@ -43,7 +43,7 @@ function! s:select(chunk)
     " end of the line, +1 is used to delete the line break at the end
     let end_pos      = final_region[1]
     let end_pos[2]   = strlen(getline(end_pos[1])) + 1
-    return ['v', start_pos, end_pos]
+    return ['V', start_pos, end_pos]
 endfunction
 
 " check the end of the current line, see if it is one of the brackets


### PR DESCRIPTION
Hey, I've been using this modification for a while but forgot to make a pull request.
Line-wise selection seems a lot more useful to me in practice, because you will always be able to paste it cleanly (the chunk can't get inserted in the middle of the current line). And you're already selecting whole lines with this text object anyway, so this doesn't change what is targeted by the text object.